### PR TITLE
Add camel case support for ClassName

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,6 @@
 {
   "processor_type" : "awesome",
+  "processor_class_name" : "{{ cookiecutter.processor_type|replace('_', ' ')|title|replace(' ', '') }}",
   "description" : "Ingest processor that is doing something awesome",
   "developer_name" : "YOUR REAL NAME",
   "elasticsearch_version" : "5.0.0-alpha4"

--- a/ingest-{{ cookiecutter.processor_type }}/README.md
+++ b/ingest-{{ cookiecutter.processor_type }}/README.md
@@ -1,4 +1,4 @@
-# Elasticsearch {{ cookiecutter.processor_type.capitalize() }} Ingest Processor
+# Elasticsearch {{ cookiecutter.processor_type|replace('_', ' ')|title }} Ingest Processor
 
 Explain the use case of this processor in a TLDR fashion.
 

--- a/ingest-{{ cookiecutter.processor_type }}/build.gradle
+++ b/ingest-{{ cookiecutter.processor_type }}/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'idea'
 esplugin {
   name 'ingest-{{ cookiecutter.processor_type }}'
   description '{{ cookiecutter.description }}'
-  classname 'org.elasticsearch.plugin.ingest.{{ cookiecutter.processor_type | lower }}.Ingest{{ cookiecutter.processor_type.capitalize() }}Plugin'
+  classname 'org.elasticsearch.plugin.ingest.{{ cookiecutter.processor_type | lower }}.Ingest{{ cookiecutter.processor_class_name }}Plugin'
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/ingest-{{ cookiecutter.processor_type }}/src/main/java/org/elasticsearch/plugin/ingest/{{ cookiecutter.processor_type }}/Ingest{{ cookiecutter.processor_class_name }}Plugin.java
+++ b/ingest-{{ cookiecutter.processor_type }}/src/main/java/org/elasticsearch/plugin/ingest/{{ cookiecutter.processor_type }}/Ingest{{ cookiecutter.processor_class_name }}Plugin.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-public class Ingest{{ cookiecutter.processor_type.capitalize() }}Plugin extends Plugin {
+public class Ingest{{ cookiecutter.processor_class_name }}Plugin extends Plugin {
 
     public static final Setting<String> YOUR_SETTING =
             new Setting<>("ingest.{{ cookiecutter.processor_type }}.setting", "foo", (value) -> value, Setting.Property.NodeScope);
@@ -37,8 +37,8 @@ public class Ingest{{ cookiecutter.processor_type.capitalize() }}Plugin extends 
     }
 
     public void onModule(NodeModule nodeModule) throws IOException {
-        nodeModule.registerProcessor({{ cookiecutter.processor_type.capitalize() }}Processor.TYPE,
-                (registry) -> new {{ cookiecutter.processor_type.capitalize() }}Processor.Factory());
+        nodeModule.registerProcessor({{ cookiecutter.processor_class_name }}Processor.TYPE,
+                (registry) -> new {{ cookiecutter.processor_class_name }}Processor.Factory());
     }
 
 }

--- a/ingest-{{ cookiecutter.processor_type }}/src/main/java/org/elasticsearch/plugin/ingest/{{ cookiecutter.processor_type }}/{{ cookiecutter.processor_class_name }}Processor.java
+++ b/ingest-{{ cookiecutter.processor_type }}/src/main/java/org/elasticsearch/plugin/ingest/{{ cookiecutter.processor_type }}/{{ cookiecutter.processor_class_name }}Processor.java
@@ -28,14 +28,14 @@ import java.util.Map;
 import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalList;
 import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
 
-public class {{ cookiecutter.processor_type.capitalize() }}Processor extends AbstractProcessor {
+public class {{ cookiecutter.processor_class_name }}Processor extends AbstractProcessor {
 
     public static final String TYPE = "{{ cookiecutter.processor_type }}";
 
     private final String field;
     private final String targetField;
 
-    public {{ cookiecutter.processor_type.capitalize() }}Processor(String tag, String field, String targetField) throws IOException {
+    public {{ cookiecutter.processor_class_name }}Processor(String tag, String field, String targetField) throws IOException {
         super(tag);
         this.field = field;
         this.targetField = targetField;
@@ -53,14 +53,14 @@ public class {{ cookiecutter.processor_type.capitalize() }}Processor extends Abs
         return TYPE;
     }
 
-    public static final class Factory extends AbstractProcessorFactory<{{ cookiecutter.processor_type.capitalize() }}Processor> {
+    public static final class Factory extends AbstractProcessorFactory<{{ cookiecutter.processor_class_name }}Processor> {
 
         @Override
-        public {{ cookiecutter.processor_type.capitalize() }}Processor doCreate(String processorTag, Map<String, Object> config) throws Exception {
+        public {{ cookiecutter.processor_class_name }}Processor doCreate(String processorTag, Map<String, Object> config) throws Exception {
             String field = readStringProperty(TYPE, processorTag, config, "field");
             String targetField = readStringProperty(TYPE, processorTag, config, "target_field", "default_field_name");
 
-            return new {{ cookiecutter.processor_type.capitalize() }}Processor(processorTag, field, targetField);
+            return new {{ cookiecutter.processor_class_name }}Processor(processorTag, field, targetField);
         }
     }
 }

--- a/ingest-{{ cookiecutter.processor_type }}/src/test/java/org/elasticsearch/plugin/ingest/{{ cookiecutter.processor_type }}/{{ cookiecutter.processor_class_name }}ProcessorTests.java
+++ b/ingest-{{ cookiecutter.processor_type }}/src/test/java/org/elasticsearch/plugin/ingest/{{ cookiecutter.processor_type }}/{{ cookiecutter.processor_class_name }}ProcessorTests.java
@@ -29,14 +29,14 @@ import java.util.Map;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
-public class {{ cookiecutter.processor_type.capitalize() }}ProcessorTests extends ESTestCase {
+public class {{ cookiecutter.processor_class_name }}ProcessorTests extends ESTestCase {
 
     public void testThatProcessorWorks() throws Exception {
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "fancy source field content");
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
 
-        {{ cookiecutter.processor_type.capitalize() }}Processor processor = new {{ cookiecutter.processor_type.capitalize() }}Processor(randomAsciiOfLength(10), "source_field", "target_field");
+        {{ cookiecutter.processor_class_name }}Processor processor = new {{ cookiecutter.processor_class_name }}Processor(randomAsciiOfLength(10), "source_field", "target_field");
         processor.execute(ingestDocument);
         Map<String, Object> data = ingestDocument.getSourceAndMetadata();
 

--- a/ingest-{{ cookiecutter.processor_type }}/src/test/java/org/elasticsearch/plugin/ingest/{{ cookiecutter.processor_type }}/{{ cookiecutter.processor_class_name }}RestIT.java
+++ b/ingest-{{ cookiecutter.processor_type }}/src/test/java/org/elasticsearch/plugin/ingest/{{ cookiecutter.processor_type }}/{{ cookiecutter.processor_class_name }}RestIT.java
@@ -25,9 +25,9 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
 
-public class {{ cookiecutter.processor_type.capitalize() }}RestIT extends ESRestTestCase {
+public class {{ cookiecutter.processor_class_name }}RestIT extends ESRestTestCase {
 
-    public {{ cookiecutter.processor_type.capitalize() }}RestIT(@Name("yaml") RestTestCandidate testCandidate) {
+    public {{ cookiecutter.processor_class_name }}RestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);
     }
 


### PR DESCRIPTION
If we set the processor_type like "date_index_name", this template create"Date_index_nameProcessor".
We should use camel case for class name.
